### PR TITLE
Fix #65

### DIFF
--- a/src/Skoruba.Duende.IdentityServer.Admin/Program.cs
+++ b/src/Skoruba.Duende.IdentityServer.Admin/Program.cs
@@ -138,8 +138,8 @@ namespace Skoruba.Duende.IdentityServer.Admin
                      configApp.AddCommandLine(args);
                  })
                 .ConfigureWebHostDefaults(webBuilder =>
-                {
-		    webBuilder.UseStaticWebAssets();
+                { 
+                    webBuilder.UseStaticWebAssets();
                     webBuilder.ConfigureKestrel(options => options.AddServerHeader = false);
                     webBuilder.UseStartup<Startup>();
                 })

--- a/src/Skoruba.Duende.IdentityServer.Admin/Program.cs
+++ b/src/Skoruba.Duende.IdentityServer.Admin/Program.cs
@@ -139,6 +139,7 @@ namespace Skoruba.Duende.IdentityServer.Admin
                  })
                 .ConfigureWebHostDefaults(webBuilder =>
                 {
+		    webBuilder.UseStaticWebAssets();
                     webBuilder.ConfigureKestrel(options => options.AddServerHeader = false);
                     webBuilder.UseStartup<Startup>();
                 })


### PR DESCRIPTION
Enable Admin.UI StaticWebAssets in non-development environments as per Microsoft's documentation:

https://docs.microsoft.com/en-us/aspnet/core/razor-pages/ui-class?view=aspnetcore-6.0&tabs=visual-studio#consume-content-from-a-referenced-rcl-1

> 
When running the consuming app from build output (dotnet run), static web assets are enabled by default in the Development environment. To support assets in other environments when running from build output, call UseStaticWebAssets on the host builder in Program.cs:

 Fix https://github.com/skoruba/Duende.IdentityServer.Admin/issues/65