### PR TITLE
POST /api/ApiScopes successfully updated the database but returns routing error.

### DIFF
--- a/src/Skoruba.Duende.IdentityServer.Admin.Api/Controllers/ApiScopesController.cs
+++ b/src/Skoruba.Duende.IdentityServer.Admin.Api/Controllers/ApiScopesController.cs
@@ -69,10 +69,10 @@ namespace Skoruba.Duende.IdentityServer.Admin.Api.Controllers
                 return BadRequest(_errorResources.CannotSetId());
             }
 
-            var id = await _apiScopeService.AddApiScopeAsync(apiScope);
-            apiScope.Id = id;
+            var apiScopeId = await _apiScopeService.AddApiScopeAsync(apiScope);
+            apiScope.Id = apiScopeId;
 
-            return CreatedAtAction(nameof(GetScope), new {scopeId = id}, apiScope);
+            return CreatedAtAction(nameof(GetScope), new {id = apiScopeId}, apiScope);
         }
 
         [HttpPost("{id}/Properties")]


### PR DESCRIPTION
Refer to ApiResourcesController.Post and note that the routeValues for CreateAtAction should have a key value of 'id'.

Without this fix I got the following error with Powershell Core

Invoke-WebRequest -Uri https://localhost:44302/api/ApiScopes -Method Post -TimeoutSec 30 -Headers System.Collections.Hashtable -Body {     <<REDACTED>> } -ContentType application/json
Invoke-WebRequest: C:\dev\identity\scripts\seed_identity.ps1:374:17
Line |
 374 |  … $response = Invoke-WebRequest -Uri $global:baseUrl/api/ApiScopes -Met …
     |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | System.InvalidOperationException: No route matches the supplied values.    at Microsoft.AspNetCore.Mvc.CreatedAtActionResult.OnFormatting(ActionContext
     | context)    at Microsoft.AspNetCore.Mvc.Infrastructure.ObjectResultExecutor.ExecuteAsyncCore(ActionContext context, ObjectResult result, Type
     | objectType, Object value)    at Microsoft.AspNetCore.Mvc.Infrastructure.ObjectResultExecutor.ExecuteAsync(ActionContext context, ObjectResult result)
     | at Microsoft.AspNetCore.Mvc.ObjectResult.ExecuteResultAsync(ActionContext context)    at
     | Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.g__Logged|22_0(ResourceInvoker invoker, IActionResult result)    at
     | Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.g__Awaited|30_0[TFilter,TFilterAsync](ResourceInvoker invoker, Task lastTask, State next, Scope
     | scope, Object state, Boolean isCompleted)    at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.Rethrow(ResultExecutedContextSealed context)
     | at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.ResultNext[TFilter,TFilterAsync](State& next, Scope& scope, Object& state, Boolean&
     | isCompleted)    at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.InvokeResultFilters() --- End of stack trace from previous location ---
     | at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.g__Awaited|25_0(ResourceInvoker invoker, Task lastTask, State next, Scope scope, Object
     | state, Boolean isCompleted)    at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.Rethrow(ResourceExecutedContextSealed context)    at
     | Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.Next(State& next, Scope& scope, Object& state, Boolean& isCompleted)    at
     | Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.g__Awaited|20_0(ResourceInvoker invoker, Task lastTask, State next, Scope scope, Object state,
     | Boolean isCompleted)    at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.g__Logged|17_1(ResourceInvoker invoker)    at
     | Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.g__Logged|17_1(ResourceInvoker invoker)    at
     | Microsoft.AspNetCore.Routing.EndpointMiddleware.g__AwaitRequestTask|6_0(Endpoint endpoint, Task requestTask, ILogger logger)    at
     | Microsoft.AspNetCore.Authorization.Policy.AuthorizationMiddlewareResultHandler.HandleAsync(RequestDelegate next, HttpContext context,
     | AuthorizationPolicy policy, PolicyAuthorizationResult authorizeResult)    at
     | Microsoft.AspNetCore.Authorization.AuthorizationMiddleware.Invoke(HttpContext context)    at
     | Microsoft.AspNetCore.Authentication.AuthenticationMiddleware.Invoke(HttpContext context)    at
     | Swashbuckle.AspNetCore.SwaggerUI.SwaggerUIMiddleware.Invoke(HttpContext httpContext)    at
     | Swashbuckle.AspNetCore.Swagger.SwaggerMiddleware.Invoke(HttpContext httpContext, ISwaggerProvider swaggerProvider)    at
     | Microsoft.AspNetCore.Diagnostics.DeveloperExceptionPageMiddleware.Invoke(HttpContext context)  HEADERS ======= Authorization: Bearer
     | <<REDACTED>>

Content-Length: 251 Content-Type: application/json Host: localhost:44302 User-Agent: Mozilla/5.0 (Windows NT 10.0; Microsoft Windows 10.0.22000; en-AU) PowerShell/7.2.5