### PR TITLE
feat: add secure secret generation with 'secret_' prefix

### DIFF
--- a/src/Skoruba.Duende.IdentityServer.Admin.UI/Areas/AdminUI/Views/Configuration/ClientSecrets.cshtml
+++ b/src/Skoruba.Duende.IdentityServer.Admin.UI/Areas/AdminUI/Views/Configuration/ClientSecrets.cshtml
@@ -56,7 +56,7 @@
                             <div class="input-group mb-3">
                                 <input id="secret-input" type="text" autocomplete="off" required class="form-control" asp-for="Value">
                                 <div class="input-group-append">
-                                    <button type="button" id="generate-guid-button" class="btn btn-primary"><span class="oi oi-random"></span></button>
+                                    <button type="button" id="generate-secret-button" class="btn btn-primary"><span class="oi oi-random"></span></button>
                                 </div>
                             </div>
                             <div class="alert alert-danger" role="alert">

--- a/src/Skoruba.Duende.IdentityServer.Admin.UI/Scripts/App/pages/Secrets.js
+++ b/src/Skoruba.Duende.IdentityServer.Admin.UI/Scripts/App/pages/Secrets.js
@@ -2,23 +2,21 @@
 
     var adminSecrets = {
 
-        guid: function () {
-            return "ss-s-s-s-sss".replace(/s/g, adminSecrets.s4);
+        generateSecret: function (byteLength) {
+            var randomValues = new Uint8Array(byteLength);
+            crypto.getRandomValues(randomValues);
+            return Array.prototype.map.call(randomValues, function (b) {
+                return ('0' + b.toString(16)).slice(-2);
+            }).join('');
         },
 
-        s4: function () {
-            return Math.floor((1 + Math.random()) * 0x10000)
-                .toString(16)
-                .substring(1);
-        },
-
-        eventHandlers: function() {
-            $("#generate-guid-button").click(function() {
-                $("#secret-input").val(adminSecrets.guid());
+        eventHandlers: function () {
+            $("#generate-secret-button").click(function () {
+                $("#secret-input").val('secret_' + adminSecrets.generateSecret(32));
             });
         },
 
-        init: function() {
+        init: function () {
 
             adminSecrets.eventHandlers();
 
@@ -26,7 +24,6 @@
 
     };
 
-
     adminSecrets.init();
 
-})
+});


### PR DESCRIPTION
This pull request introduces a cryptographically secure secret generation feature. The updated code provides a more robust and secure way to create secrets using the Web Cryptography API's crypto.getRandomValues function.

The main changes in this PR are:

- Replacing the previous GUID-based secret generation method with a more flexible and secure approach that generates a random byte array and converts it to a hexadecimal string.
- Adding a "secret_" prefix to the generated secret to provide better context and readability. This is recommended here: https://www.oauth.com/oauth2-servers/client-registration/client-id-secret/