### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ On windows `mkcert -install` must be executed under elevated Administrator privi
 ```bash
 cd shared/nginx/certs
 mkcert --install
-copy $env:LOCALAPPDATA\mkcert\rootCA.pem ./cacerts.pem
+copy $env:LOCALAPPDATA\mkcert\rootCA-key.pem ./cacerts.pem
 copy $env:LOCALAPPDATA\mkcert\rootCA.pem ./cacerts.crt
 ```
 ##### Create the `skoruba.local` certificates


### PR DESCRIPTION
cacerts.pem path modified
The current one was wrong.

ref: https://github.com/skoruba/Duende.IdentityServer.Admin/tree/release/1.3.0?tab=readme-ov-file#running-via-docker