### PR TITLE
chore(username-validation): remove regex

### DIFF
--- a/src/Skoruba.Duende.IdentityServer.Admin.BusinessLogic.Identity/Dtos/Identity/UserDto.cs
+++ b/src/Skoruba.Duende.IdentityServer.Admin.BusinessLogic.Identity/Dtos/Identity/UserDto.cs
@@ -1,17 +1,16 @@
 ﻿// Copyright (c) Jan Škoruba. All Rights Reserved.
 // Licensed under the Apache License, Version 2.0.
 
-using System;
-using System.ComponentModel.DataAnnotations;
 using Skoruba.Duende.IdentityServer.Admin.BusinessLogic.Identity.Dtos.Identity.Base;
 using Skoruba.Duende.IdentityServer.Admin.BusinessLogic.Identity.Dtos.Identity.Interfaces;
+using System;
+using System.ComponentModel.DataAnnotations;
 
 namespace Skoruba.Duende.IdentityServer.Admin.BusinessLogic.Identity.Dtos.Identity
 {
     public class UserDto<TKey> : BaseUserDto<TKey>, IUserDto
-    {        
+    {
         [Required]
-        [RegularExpression(@"^[a-zA-Z0-9_@\-\.\+]+$")]
         public string UserName { get; set; }
 
         [Required]

--- a/src/Skoruba.Duende.IdentityServer.Admin.BusinessLogic.Identity/Dtos/Identity/UserDto.cs
+++ b/src/Skoruba.Duende.IdentityServer.Admin.BusinessLogic.Identity/Dtos/Identity/UserDto.cs
@@ -1,10 +1,10 @@
 ﻿// Copyright (c) Jan Škoruba. All Rights Reserved.
 // Licensed under the Apache License, Version 2.0.
 
-using Skoruba.Duende.IdentityServer.Admin.BusinessLogic.Identity.Dtos.Identity.Base;
-using Skoruba.Duende.IdentityServer.Admin.BusinessLogic.Identity.Dtos.Identity.Interfaces;
 using System;
 using System.ComponentModel.DataAnnotations;
+using Skoruba.Duende.IdentityServer.Admin.BusinessLogic.Identity.Dtos.Identity.Base;
+using Skoruba.Duende.IdentityServer.Admin.BusinessLogic.Identity.Dtos.Identity.Interfaces;
 
 namespace Skoruba.Duende.IdentityServer.Admin.BusinessLogic.Identity.Dtos.Identity
 {

--- a/src/Skoruba.Duende.IdentityServer.STS.Identity/ViewModels/Account/ExternalLoginConfirmationViewModel.cs
+++ b/src/Skoruba.Duende.IdentityServer.STS.Identity/ViewModels/Account/ExternalLoginConfirmationViewModel.cs
@@ -5,7 +5,6 @@ namespace Skoruba.Duende.IdentityServer.STS.Identity.ViewModels.Account
     public class ExternalLoginConfirmationViewModel
     {
         [Required]
-        [RegularExpression(@"^[a-zA-Z0-9_@\-\.\+]+$")]
         public string UserName { get; set; }
 
         [Required]


### PR DESCRIPTION
Right now there's a regex on the username property of the UserDto, which is a problem because:
1.  It is not configurable (the current regex is a problem for German names 😢)
2. (and more important) Even if it is changed in the source code, the username will still be checked against the [UserOptions.AllowedUserNameCharacters Property](https://learn.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.identity.useroptions.allowedusernamecharacters?view=aspnetcore-8.0), which can be configured via appsettings (Defaults to abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._@+). So you would need to change the regex on two positions.

With the help of this PR, the AspNetCore.Identity Regex will be used exclusively.

This PR fixes #156