### PR TITLE
chore(ApiScopes): disable auto-publish in discovery document

### DIFF
--- a/src/Skoruba.Duende.IdentityServer.Admin.BusinessLogic/Dtos/Configuration/ApiScopeDto.cs
+++ b/src/Skoruba.Duende.IdentityServer.Admin.BusinessLogic/Dtos/Configuration/ApiScopeDto.cs
@@ -6,34 +6,34 @@ using System.ComponentModel.DataAnnotations;
 
 namespace Skoruba.Duende.IdentityServer.Admin.BusinessLogic.Dtos.Configuration
 {
-	public class ApiScopeDto
-	{
-		public ApiScopeDto()
-		{
-			UserClaims = new List<string>();
-		}
+    public class ApiScopeDto
+    {
+        public ApiScopeDto()
+        {
+            UserClaims = new List<string>();
+        }
 
-		public bool ShowInDiscoveryDocument { get; set; } = true;
+        public bool ShowInDiscoveryDocument { get; set; }
 
-		public int Id { get; set; }
+        public int Id { get; set; }
 
         [Required]
-		public string Name { get; set; }
+        public string Name { get; set; }
 
-		public string DisplayName { get; set; }
+        public string DisplayName { get; set; }
 
-		public string Description { get; set; }
+        public string Description { get; set; }
 
-		public bool Required { get; set; }
+        public bool Required { get; set; }
 
-		public bool Emphasize { get; set; }
+        public bool Emphasize { get; set; }
 
-		public List<string> UserClaims { get; set; }
+        public List<string> UserClaims { get; set; }
 
         public string UserClaimsItems { get; set; }
 
-		public bool Enabled { get; set; } = true;
+        public bool Enabled { get; set; } = true;
 
         public List<ApiScopePropertyDto> ApiScopeProperties { get; set; }
-	}
+    }
 }


### PR DESCRIPTION
This PR follows the idea of "security by default" and disables the auto-publishing of new ApiScopes via the discovery document.