### PR TITLE
Add Support for Visual Studio Code

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,52 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "IdentityServer",
+            "type": "coreclr",
+            "request": "launch",      
+            "preLaunchTask": "build",     
+            "program": "${workspaceFolder}/src/Skoruba.Duende.IdentityServer.STS.Identity/bin/Debug/net9.0/Skoruba.Duende.IdentityServer.STS.Identity.dll",
+            "cwd": "${workspaceFolder}/src/Skoruba.Duende.IdentityServer.STS.Identity",
+            "stopAtEntry": false,
+            "serverReadyAction": {
+                "action": "openExternally",
+                "pattern": "\\bNow listening on:\\s+(https?://\\S+)"
+            },
+            "env": {
+                "ASPNETCORE_ENVIRONMENT": "Development"
+            },
+            "sourceFileMap": {
+                "/Views": "${workspaceFolder}/src/Skoruba.Duende.IdentityServer.STS.Identity/Views"
+            }
+        },
+        {
+            "name": "IdentityServerAdmin",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "build",
+            "program": "${workspaceFolder}/src/Skoruba.Duende.IdentityServer.Admin/bin/Debug/net9.0/Skoruba.Duende.IdentityServer.Admin.dll",
+            "cwd": "${workspaceFolder}/src/Skoruba.Duende.IdentityServer.Admin",
+            "stopAtEntry": false,
+            "serverReadyAction": {
+                "action": "openExternally",
+                "pattern": "\\bNow listening on:\\s+(https?://\\S+)"
+            },
+            "env": {
+                "ASPNETCORE_ENVIRONMENT": "Development",             
+            },
+            "sourceFileMap": {
+                "/Views": "${workspaceFolder}/src/Skoruba.Duende.IdentityServer.Admin/Views"
+            }
+        }
+    ],
+    "compounds": [
+        {
+            "name": "Run Both Projects",
+            "configurations": ["IdentityServer", "IdentityServerAdmin"]
+        }
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,19 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "build",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "build",
+                "${workspaceFolder}/Skoruba.Duende.IdentityServer.Admin.sln"
+            ],
+            "problemMatcher": "$msCompile",
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            }
+        }
+    ]
+}

--- a/src/Skoruba.Duende.IdentityServer.Admin/serilog.json
+++ b/src/Skoruba.Duende.IdentityServer.Admin/serilog.json
@@ -1,14 +1,19 @@
 ﻿{
     "Serilog": {
         "MinimumLevel": {
-            "Default": "Error",
+            "Default": "Information",
             "Override": {
-                "Skoruba": "Information"
+                "Skoruba": "Information",
+                "Microsoft": "Information",
+                "Microsoft.Hosting.Lifetime": "Information"
             }
         },
         "WriteTo": [
             {
-                "Name": "Console"
+                "Name": "Console",
+                "Args": {
+                    "outputTemplate": "[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj}{NewLine}{Exception}"
+                }
             },
             {
                 "Name": "File",


### PR DESCRIPTION
### Overview:
This PR introduces support for developing and debugging the solution using Visual Studio Code, while maintaining full compatibility with Visual Studio 2022. As the developer landscape shifts toward lighter editors, VS Code has become increasingly popular—particularly for its rich ecosystem of AI-powered extensions that are not available in Visual Studio.

### Motivation:
My primary motivation for adding VS Code support is the availability of advanced AI tools that significantly enhance development productivity. These tools are not currently supported in Visual Studio, making VS Code a more appealing choice for modern development workflows.

### Main Changes:

**VS Code Configuration Files Added:**

launch.json: Enables running and debugging projects directly in VS Code.

tasks.json: Defines tasks to build and run the projects efficiently within VS Code.

**Automatic Browser Launch (for Web Projects):**

VS Code requires a different approach to open a browser upon project startup.

It listens to the terminal for the log output string:

"Now listening on: https://localhost:XXXX"

To support this, Serilog has been configured to ensure this output is correctly emitted during application startup.

With these additions, developers can now choose to work with either Visual Studio 2022 or Visual Studio Code without any extra configuration.

P.S. Runs 2 projects "IdentityServer" (Skoruba.Duende.IdentityServer.STS.Identity) and "IdentityServerAdmin" (Skoruba.Duende.IdentityServer.Admin)