### PR TITLE
fix(Duende.IdentityServer): update to v7.3.1

### DIFF
--- a/src/Skoruba.Duende.IdentityServer.Admin.BusinessLogic.Identity/Skoruba.Duende.IdentityServer.Admin.BusinessLogic.Identity.csproj
+++ b/src/Skoruba.Duende.IdentityServer.Admin.BusinessLogic.Identity/Skoruba.Duende.IdentityServer.Admin.BusinessLogic.Identity.csproj
@@ -6,7 +6,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Duende.IdentityServer.EntityFramework" Version="7.2.1" />
+		<PackageReference Include="Duende.IdentityServer.EntityFramework" Version="7.3.1" />
 		<PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="9.0.4" />
 	</ItemGroup>
 

--- a/src/Skoruba.Duende.IdentityServer.Admin.BusinessLogic/Skoruba.Duende.IdentityServer.Admin.BusinessLogic.csproj
+++ b/src/Skoruba.Duende.IdentityServer.Admin.BusinessLogic/Skoruba.Duende.IdentityServer.Admin.BusinessLogic.csproj
@@ -7,7 +7,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="AutoMapper" Version="14.0.0" />
-		<PackageReference Include="Duende.IdentityServer.EntityFramework" Version="7.2.1" />
+		<PackageReference Include="Duende.IdentityServer.EntityFramework" Version="7.3.1" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Skoruba.Duende.IdentityServer.Admin.EntityFramework.Identity/Skoruba.Duende.IdentityServer.Admin.EntityFramework.Identity.csproj
+++ b/src/Skoruba.Duende.IdentityServer.Admin.EntityFramework.Identity/Skoruba.Duende.IdentityServer.Admin.EntityFramework.Identity.csproj
@@ -7,7 +7,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="AutoMapper" Version="14.0.0" />
-		<PackageReference Include="Duende.IdentityServer.EntityFramework" Version="7.2.1" />
+		<PackageReference Include="Duende.IdentityServer.EntityFramework" Version="7.3.1" />
 		<PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="9.0.4" />
 	</ItemGroup>
 

--- a/src/Skoruba.Duende.IdentityServer.Admin.EntityFramework/Skoruba.Duende.IdentityServer.Admin.EntityFramework.csproj
+++ b/src/Skoruba.Duende.IdentityServer.Admin.EntityFramework/Skoruba.Duende.IdentityServer.Admin.EntityFramework.csproj
@@ -6,7 +6,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Duende.IdentityServer.EntityFramework" Version="7.2.1" />
+		<PackageReference Include="Duende.IdentityServer.EntityFramework" Version="7.3.1" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="9.0.4" />
 		<PackageReference Include="Skoruba.AuditLogging.EntityFramework" Version="2.0.0" />
 	</ItemGroup>

--- a/src/Skoruba.Duende.IdentityServer.Admin/Skoruba.Duende.IdentityServer.Admin.csproj
+++ b/src/Skoruba.Duende.IdentityServer.Admin/Skoruba.Duende.IdentityServer.Admin.csproj
@@ -11,7 +11,7 @@
 	<ItemGroup>
 		<PackageReference Include="AspNetCore.HealthChecks.UI" Version="9.0.0" />
 		<PackageReference Include="AutoMapper" Version="14.0.0" />
-		<PackageReference Include="Duende.IdentityServer.EntityFramework" Version="7.2.1" />
+		<PackageReference Include="Duende.IdentityServer.EntityFramework" Version="7.3.1" />
 		<PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="9.0.4" />
 		<PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="9.0.4" />
 		<PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="9.0.4" />

--- a/src/Skoruba.Duende.IdentityServer.STS.Identity/Skoruba.Duende.IdentityServer.STS.Identity.csproj
+++ b/src/Skoruba.Duende.IdentityServer.STS.Identity/Skoruba.Duende.IdentityServer.STS.Identity.csproj
@@ -30,8 +30,8 @@
 		<PackageReference Include="Microsoft.Identity.Web" Version="3.8.3" />
 		<PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.2" />
 		<PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="9.0.4" />
-        <PackageReference Include="Duende.IdentityServer.AspNetIdentity" Version="7.2.1" />
-        <PackageReference Include="Duende.IdentityServer.EntityFramework" Version="7.2.1" />
+        <PackageReference Include="Duende.IdentityServer.AspNetIdentity" Version="7.3.1" />
+        <PackageReference Include="Duende.IdentityServer.EntityFramework" Version="7.3.1" />
 		<PackageReference Include="Serilog" Version="4.2.0" />
 		<PackageReference Include="Serilog.Enrichers.Environment" Version="3.0.1" />
 		<PackageReference Include="Serilog.Enrichers.Thread" Version="4.0.0" />

--- a/tests/Skoruba.Duende.IdentityServer.STS.Identity.IntegrationTests/Skoruba.Duende.IdentityServer.STS.Identity.IntegrationTests.csproj
+++ b/tests/Skoruba.Duende.IdentityServer.STS.Identity.IntegrationTests/Skoruba.Duende.IdentityServer.STS.Identity.IntegrationTests.csproj
@@ -10,7 +10,7 @@
     <ItemGroup>
         <PackageReference Include="FluentAssertions" Version="6.12.1" />
         <PackageReference Include="HtmlAgilityPack" Version="1.12.1" />
-        <PackageReference Include="Duende.IdentityModel" Version="7.0.0" />
+        <PackageReference Include="Duende.IdentityModel" Version="7.1.0" />
         <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.4" />
         <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="9.0.4" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />


### PR DESCRIPTION
Hi @skoruba,
Right now (at least for me) the AdminUI is not compatible with Duende 7.3.x due to the following error

`Could not load file or assembly 'Duende.IdentityServer.EntityFramework.Storage, Version=7.2.1.0`
This stems from the Admin.UI having the dependency to the old 7.2.1 version.

This PR updates the Duende Package to the current version (v7.3.1)