### PR TITLE
Fix: Role claim type

### DIFF
--- a/src/Skoruba.Duende.IdentityServer.Admin.Api/Configuration/Test/StartupTest.cs
+++ b/src/Skoruba.Duende.IdentityServer.Admin.Api/Configuration/Test/StartupTest.cs
@@ -10,6 +10,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Skoruba.Duende.IdentityServer.Admin.EntityFramework.Configuration.Configuration;
 using Skoruba.Duende.IdentityServer.Admin.EntityFramework.Shared.DbContexts;
 using Skoruba.Duende.IdentityServer.Admin.EntityFramework.Shared.Entities.Identity;
+using Skoruba.Duende.IdentityServer.Admin.UI.Api.Configuration;
 using Skoruba.Duende.IdentityServer.Admin.UI.Api.Helpers;
 using Skoruba.Duende.IdentityServer.Admin.UI.Api.Middlewares;
 using Skoruba.Duende.IdentityServer.Shared.Configuration.Constants;
@@ -50,9 +51,9 @@ namespace Skoruba.Duende.IdentityServer.Admin.Api.Configuration.Test
             }).AddCookie(JwtBearerDefaults.AuthenticationScheme);
         }
 
-        public override void RegisterAuthorization(IServiceCollection services)
+        public override void RegisterAuthorization(IServiceCollection services, AdminApiConfiguration adminApiConfiguration)
         {
-            services.AddAuthorizationPolicies();
+            services.AddAuthorizationPolicies(adminApiConfiguration);
         }
 
         public override void UseAuthentication(IApplicationBuilder app)

--- a/src/Skoruba.Duende.IdentityServer.Admin.Api/Startup.cs
+++ b/src/Skoruba.Duende.IdentityServer.Admin.Api/Startup.cs
@@ -55,7 +55,7 @@ namespace Skoruba.Duende.IdentityServer.Admin.Api
             RegisterAuthentication(services);
 
             // Add authorization services
-            RegisterAuthorization(services);
+            RegisterAuthorization(services, adminApiConfiguration);
 
             services.AddIdentityServerAdminApi<AdminIdentityDbContext, IdentityServerConfigurationDbContext, IdentityServerPersistedGrantDbContext, IdentityServerDataProtectionDbContext, AdminLogDbContext, AdminAuditLogDbContext, AdminConfigurationDbContext, AuditLog,
                 IdentityUserDto, IdentityRoleDto, UserIdentity, UserIdentityRole, string, UserIdentityUserClaim, UserIdentityUserRole,
@@ -116,9 +116,9 @@ namespace Skoruba.Duende.IdentityServer.Admin.Api
             services.AddApiAuthentication<AdminIdentityDbContext, UserIdentity, UserIdentityRole>(Configuration);
         }
 
-        public virtual void RegisterAuthorization(IServiceCollection services)
+        public virtual void RegisterAuthorization(IServiceCollection services, AdminApiConfiguration adminApiConfiguration)
         {
-            services.AddAuthorizationPolicies();
+            services.AddAuthorizationPolicies(adminApiConfiguration);
         }
 
         public virtual void UseAuthentication(IApplicationBuilder app)

--- a/src/Skoruba.Duende.IdentityServer.Admin.UI.Api/Helpers/StartupHelpers.cs
+++ b/src/Skoruba.Duende.IdentityServer.Admin.UI.Api/Helpers/StartupHelpers.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Net;
-using System.Reflection;
 using NetIPNetwork = System.Net.IPNetwork;
 using Duende.IdentityServer.EntityFramework.Options;
 using IdentityModel;
@@ -36,7 +35,6 @@ using Skoruba.Duende.IdentityServer.Admin.EntityFramework.Helpers;
 using Skoruba.Duende.IdentityServer.Admin.EntityFramework.Interfaces;
 using Skoruba.Duende.IdentityServer.Admin.EntityFramework.Repositories;
 using Skoruba.Duende.IdentityServer.Admin.EntityFramework.Repositories.Interfaces;
-using Skoruba.Duende.IdentityServer.Admin.EntityFramework.Shared.Extensions;
 using Skoruba.Duende.IdentityServer.Admin.UI.Api.Configuration;
 using Skoruba.Duende.IdentityServer.Admin.UI.Api.Configuration.ApplicationParts;
 using Skoruba.Duende.IdentityServer.Admin.UI.Api.Configuration.AuditLogging;
@@ -225,6 +223,7 @@ namespace Skoruba.Duende.IdentityServer.Admin.UI.Api.Helpers
                     options.Authority = adminApiConfiguration.IdentityServerBaseUrl;
                     options.RequireHttpsMetadata = adminApiConfiguration.RequireHttpsMetadata;
                     options.Audience = adminApiConfiguration.OidcApiName;
+                    options.TokenValidationParameters.RoleClaimType = JwtClaimTypes.Role;
                 });
         }
 
@@ -268,19 +267,15 @@ namespace Skoruba.Duende.IdentityServer.Admin.UI.Api.Helpers
             services.AddDbContext<TDataProtectionDbContext>(optionsBuilder => optionsBuilder.UseInMemoryDatabase(dataProtectionDatabaseName));
         }
 
-        public static void AddAuthorizationPolicies(this IServiceCollection services)
+        public static void AddAuthorizationPolicies(this IServiceCollection services, AdminApiConfiguration adminApiConfiguration)
         {
-            var adminApiConfiguration = services.BuildServiceProvider().GetService<AdminApiConfiguration>();
-
             services.AddAuthorization(options =>
             {
                 options.AddPolicy(AuthorizationConsts.AdministrationPolicy,
                     policy =>
-                        policy.RequireAssertion(context => context.User.HasClaim(c =>
-                                ((c.Type == JwtClaimTypes.Role && c.Value == adminApiConfiguration.AdministrationRole) ||
-                                 (c.Type == $"client_{JwtClaimTypes.Role}" && c.Value == adminApiConfiguration.AdministrationRole))
-                            ) && context.User.HasClaim(c => c.Type == JwtClaimTypes.Scope && c.Value == adminApiConfiguration.OidcApiName)
-                        ));
+                        policy
+                            .RequireRole(adminApiConfiguration.AdministrationRole)
+                            .RequireClaim(JwtClaimTypes.Scope, adminApiConfiguration.OidcApiName));
             });
         }
 


### PR DESCRIPTION
Although Duende IdentityServer by default uses `"role"` as a role claim type, this can be configured to be something else. Currently, Duende.IdentityServer.Admin (3.x preview) does not support this, as the authorization policy in the underlying API checks for a claim with type `JwtClaimTypes.Role` (i.e. `"role"`) instead of setting the correct Role Claim Type.

By fixing this, users using a different claim type for roles can also override this in their Duende.IdentityServer.Admin by configuring their JwtBearerOptions.